### PR TITLE
feat(Tool Modal Enhancements): Dark-Light Mode and onBackdropClick

### DIFF
--- a/src/components/ToolModal.tsx
+++ b/src/components/ToolModal.tsx
@@ -53,7 +53,7 @@ export function ToolModal({
     >
       {/* The Image in the expanded view */}
       <div
-        className={`modal-image relative mb-6 min-h-[200px] w-full transition-all duration-600 ease-out ${
+        className={`modal-image relative mb-6 min-h-[200px] w-fit transition-all duration-600 ease-out ${
           isExiting ? "modal-image-exit" : ""
         }`}
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Tool Modal Enhancements

1. Modal Text and BG - Dark and Light Mode Specific
    - For proper **mode distinction** in user subconscious
<img width="640" height="800" alt="Screenshot 2025-11-03 at 1 27 51 PM" src="https://github.com/user-attachments/assets/59473b27-cc0a-458c-af8e-62ecf69ce96e" />

---

2. Added Backdrop Blur for better UX
    - as solid white was not giving a **sense of opened modal** 
<img width="640" height="800" alt="Screenshot 2025-11-03 at 1 28 42 PM" src="https://github.com/user-attachments/assets/b121fce5-80bc-409a-bbb3-43430950f3e0" />

---

3. Modal Image Changed w-full to w-fit for proper onBackDropClick
    - as earlier if user clicked in horizontal range of image then **onClose() was not working and thus resulting to poor UX**
<img width="640" height="800" alt="Screenshot 2025-11-03 at 1 10 05 PM" src="https://github.com/user-attachments/assets/f809d673-051d-45f0-8b00-31a839f4be61" />

